### PR TITLE
Update broccoli-filter to latest.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "autoprefixer-core": "^3.0.0",
-    "broccoli-filter": "^0.1.6",
+    "broccoli-filter": "^0.1.7",
     "object-assign": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Without this, we get older versions of broccoli-kitchen-sink-helpers
that do not properly handle symlinks.

Same issue as described in broccolijs/broccoli-filter#16.
