### PR TITLE
Update `autoprefixer`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     "postcss": "^7.0.2"
   },
   "devDependencies": {
-    "ava": "*",
+    "ava": "1.0.1",
     "broccoli": "^1.1.1",
     "broccoli-cli": "^1.0.0",
     "del": "^3.0.0",
-    "xo": "*"
+    "xo": "0.23.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "postcss-runner"
   ],
   "dependencies": {
-    "autoprefixer": "^9.0.2",
+    "autoprefixer": "^9.7.6",
     "broccoli-persistent-filter": "^1.1.6",
     "postcss": "^7.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "postcss-runner"
   ],
   "dependencies": {
-    "autoprefixer": "^9.7.6",
+    "autoprefixer": "^9.8.4",
     "broccoli-persistent-filter": "^1.1.6",
     "postcss": "^7.0.2"
   },


### PR DESCRIPTION
[autoprefixer changelong](https://github.com/postcss/autoprefixer/blob/master/CHANGELOG.md#976)

Locking devDependencies to keep support for older node versions